### PR TITLE
verify: enforce verification-only boundary across README and host surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ Public verification repository for `https://verify.verifrax.net/`, serving a sta
 
 This repository owns the public verifier surface.
 
+Verification is not publication. Verification is not execution. Verification is not authority.
+
+## Verifier role boundary
+
+This repository is the public verification surface only.
+
+It exists to inspect published proof material and return verification results.
+
+It is not proof publication.
+It is not authority issuance.
+It is not governed execution.
+
+
 Its job is to make verification available publicly, portably, and inspectably.
 
 It exists so a reader can:
@@ -51,38 +64,10 @@ That separation is the point.
 
 ## What this repository is not
 
-`VERIFRAX-verify` is not:
-
-* the authority layer
-* the execution runtime
-* the proof publication repository
-* the evidence-root repository
-* the seal/archive repository
-* the intake surface
-* the commercial surface
-* the docs root
-* a mutable server-side verification service with hidden trust
-* an authority object issuer
-* a CORPIFORM receipt emitter
-* the artifact registry for `artifact-0005`
-
-It does not:
-
-* publish proof records to `proof.verifrax.net`
-* issue authority objects for `auctoriseal.verifrax.net`
-* execute governed actions at `api.verifrax.net`
-* produce receipts for `corpiform.verifrax.net`
-* register artifact-chain truth in the `VERIFRAX` evidence root
-* replace `proof.verifrax.net`
-* replace `SIGILLARIUM`
-* convert a proof display into authority truth by itself
-
-Verification is not publication.
-Verification is not execution.
-Verification is not authority.
-
-If that line blurs, the repository is already wrong.
-
+This repository is not proof publication.
+This repository is not authority issuance.
+This repository is not governed execution.
+This repository is not intake.
 ## Public host ownership
 
 This repository owns exactly this public host:

--- a/dist/index.html
+++ b/dist/index.html
@@ -16,7 +16,9 @@
 <body>
   <main class="surface stack">
     <div class="surface-id">VERIFRAX / verify</div>
-    <h1 class="surface-title">VERIFRAX Verify</h1>
+    \1
+<p>Canonical verification surface.</p>
+<p>This surface verifies published proof. It does not publish proof, issue authority, execute governed actions, or accept intake.</p>
     <p class="surface-role">Public verifier surface for proof structure inspection.</p>
     <p class="surface-boundary">This surface inspects proof structure. It does not publish proof, issue authority, execute runtime actions, or operate archive retrieval.</p>
 

--- a/index.html
+++ b/index.html
@@ -16,7 +16,9 @@
 <body>
   <main class="surface stack">
     <div class="surface-id">VERIFRAX / verify</div>
-    <h1 class="surface-title">VERIFRAX Verify</h1>
+    \1
+<p>Canonical verification surface.</p>
+<p>This surface verifies published proof. It does not publish proof, issue authority, execute governed actions, or accept intake.</p>
     <p class="surface-role">Public verifier surface for proof structure inspection.</p>
     <p class="surface-boundary">This surface inspects proof structure. It does not publish proof, issue authority, execute runtime actions, or operate archive retrieval.</p>
 

--- a/surface-preview/404.html
+++ b/surface-preview/404.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>VERIFRAX Verify</title>
-  <meta name="description" content="Public verification surface for deterministic proof inspection.">
+  <meta name="description" content="Public verifier surface for proof structure inspection.">
   <link rel="stylesheet" href="assets/surface.css">
 </head>
 <body>
   <main class="wrap">
     <div class="kicker">VERIFRAX / verify</div>
     <h1>404 — VERIFRAX Verify</h1>
-    <p class="lead">Public verification surface for deterministic proof inspection.</p>
+    <p class="lead">Public verifier surface for proof structure inspection.</p>
     <p class="copy">Bounded public tool surface inside the VERIFRAX perimeter.</p>
     <div class="rule"></div>
 

--- a/surface-preview/index.html
+++ b/surface-preview/index.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>VERIFRAX Verify</title>
-  <meta name="description" content="Public verification surface for deterministic proof inspection.">
+  <meta name="description" content="Public verifier surface for proof structure inspection.">
   <link rel="stylesheet" href="assets/surface.css">
 </head>
 <body>
   <main class="wrap">
     <div class="kicker">VERIFRAX / verify</div>
     <h1>VERIFRAX Verify</h1>
-    <p class="lead">Public verification surface for deterministic proof inspection.</p>
+    <p class="lead">Public verifier surface for proof structure inspection.</p>
     <p class="copy">Bounded public tool surface inside the VERIFRAX perimeter.</p>
     <div class="rule"></div>
 


### PR DESCRIPTION
## Summary
Align the public verifier surface to one bounded role only.

## Changes
- add explicit verification-only boundary sentence to README
- add explicit verifier role and non-role sections
- add explicit verification identity line to host surfaces
- add explicit host-surface boundary sentence excluding proof publication, authority, execution, and intake

## Boundary held
- verify verifies
- verify does not publish proof
- verify does not issue authority
- verify does not execute
- verify does not accept intake