### PR TITLE
Promote verifier to deterministic public verdict surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,31 @@
 # VERIFRAX-verify
 
+Deterministic public verdict surface.
+
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue)
 ![Surface](https://img.shields.io/badge/surface-public%20verifier-111111)
 ![Host](https://img.shields.io/badge/host-verify.verifrax.net-1f6feb)
 
 Public verification repository for `https://verify.verifrax.net/`, serving a static verification surface for Verifrax proof material without becoming an authority issuer, proof publisher, execution runtime, archive surface, or evidence-root repository.
+
+
+## Public verdict contract
+
+This surface publishes a reproducible public verdict contract.
+
+Required fields:
+- `law_ref`
+- `state_ref`
+- `proof_ref`
+- `execution_ref`
+- `verifier_version`
+- `verdict`
+- `reason_codes`
+- `contradictions`
+- `generated_at`
+
+Demo artifact:
+- `public/verdict.json`
 
 ## Status
 

--- a/fixtures/verdict/minimal-verdict.json
+++ b/fixtures/verdict/minimal-verdict.json
@@ -1,0 +1,13 @@
+{
+  "law_ref": "SYNTAGMARIUM@6657b6369a884ad6d0677679aedaab5c82274a7b",
+  "state_ref": "ORBISTIUM@current",
+  "proof_ref": "proof:artifact-0001",
+  "execution_ref": "receipt:example-0001",
+  "verifier_version": "0.2.0",
+  "verdict": "INDETERMINATE",
+  "reason_codes": [
+    "FIXTURE_ONLY"
+  ],
+  "contradictions": [],
+  "generated_at": "2026-04-09T00:00:00Z"
+}

--- a/public/verdict.json
+++ b/public/verdict.json
@@ -1,0 +1,13 @@
+{
+  "law_ref": "SYNTAGMARIUM@main",
+  "state_ref": "ORBISTIUM@current",
+  "proof_ref": "proof:artifact-0001",
+  "execution_ref": "receipt:example-0001",
+  "verifier_version": "0.2.0",
+  "verdict": "INDETERMINATE",
+  "reason_codes": [
+    "PUBLIC_DEMO_FIXTURE"
+  ],
+  "contradictions": [],
+  "generated_at": "2026-04-09T00:00:00Z"
+}

--- a/tests/test_verdict_contract.py
+++ b/tests/test_verdict_contract.py
@@ -1,0 +1,31 @@
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+class VerdictContractTest(unittest.TestCase):
+    def test_public_verdict_json_loads(self):
+        payload = json.loads((ROOT / "public" / "verdict.json").read_text(encoding="utf-8"))
+        self.assertEqual(
+            sorted(payload.keys()),
+            [
+                "contradictions",
+                "execution_ref",
+                "generated_at",
+                "law_ref",
+                "proof_ref",
+                "reason_codes",
+                "state_ref",
+                "verdict",
+                "verifier_version",
+            ],
+        )
+
+    def test_fixture_verdict_uses_pinned_law(self):
+        payload = json.loads((ROOT / "fixtures" / "verdict" / "minimal-verdict.json").read_text(encoding="utf-8"))
+        self.assertTrue(payload["law_ref"].startswith("SYNTAGMARIUM@"))
+        self.assertIn(payload["verdict"], {"PASS", "FAIL", "INDETERMINATE", "CONTRADICTED"})
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

- replaced inspection-only positioning with deterministic public verdict positioning
- added public verdict contract artifact
- added minimal verdict fixture
- added verdict contract tests

## Validation

- python3 -m json.tool public/verdict.json >/dev/null
- python3 -m json.tool fixtures/verdict/minimal-verdict.json >/dev/null
- python3 -m unittest tests/test_verdict_contract.py -v