### PR TITLE
Realign verify host surface

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>VERIFRAX Verify</title>
-  <meta name="description" content="Public verifier surface for proof structure inspection. This surface verifies published proof. It does not publish proof, issue authority, execute governed actions, or accept intake.">
+  <meta name="description" content="Verification surface for the VERIFRAX public perimeter. This surface verifies published proof. It does not publish proof, issue authority, execute governed actions, or accept intake.">
   <link rel="canonical" href="https://verify.verifrax.net/">
   <link rel="stylesheet" href="assets/surface.css">
 </head>
@@ -12,7 +12,7 @@
   <main class="wrap">
     <div class="kicker">VERIFRAX / verify</div>
     <h1>404 — VERIFRAX Verify</h1>
-    <p class="lead">Public verifier surface for proof structure inspection. This surface verifies published proof. It does not publish proof, issue authority, execute governed actions, or accept intake.</p>
+    <p class="lead">Verification surface for the VERIFRAX public perimeter. This surface verifies published proof. It does not publish proof, issue authority, execute governed actions, or accept intake.</p>
     <p class="copy">Bounded public tool surface inside the VERIFRAX perimeter.</p>
     <div class="rule"></div>
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>VERIFRAX Verify</title>
-  <meta name="description" content="Public verifier surface for proof structure inspection.">
+  <meta name="description" content="Verification surface for the VERIFRAX public perimeter.">
   <style>
     @import url("./surface-system/shell/base.css");
     textarea{width:100%;min-height:220px;font-family:var(--vf-font-mono);background:var(--vf-panel-2);color:var(--vf-text);border:1px solid var(--vf-line);border-radius:var(--vf-radius-2);padding:var(--vf-space-4)}
@@ -19,7 +19,7 @@
     
 <p>Canonical verification surface.</p>
 <p>This surface verifies published proof. It does not publish proof, issue authority, execute governed actions, or accept intake.</p>
-    <p class="surface-role">Public verifier surface for proof structure inspection.</p>
+    <p class="surface-role">Verification surface for the VERIFRAX public perimeter.</p>
     <p class="surface-boundary">This surface inspects proof structure. It does not publish proof, issue authority, execute runtime actions, or operate archive retrieval.</p>
 
     <section class="panel">
@@ -52,6 +52,19 @@
         <a href="https://status.verifrax.net/">Status</a>
       </div>
     </section>
+  
+    <div class="pills">
+        <a href="https://www.verifrax.net/">Root</a>
+        <a href="https://proof.verifrax.net/">Proof</a>
+        <a href="https://docs.verifrax.net/">Docs</a>
+        <a href="https://apply.verifrax.net/">Apply</a>
+        <a href="https://api.verifrax.net/">Execution</a>
+        <a href="https://auctoriseal.verifrax.net/">Authority</a>
+        <a href="https://corpiform.verifrax.net/">Runtime</a>
+        <a href="https://cicullis.verifrax.net/">Enforcement</a>
+        <a href="https://sigillarium.verifrax.net/">Archive</a>
+        <a href="https://status.verifrax.net/">Status</a>
+    </div>
   </main>
 
   <script>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>VERIFRAX Verify</title>
-  <meta name="description" content="Public verifier surface for proof structure inspection.">
+  <meta name="description" content="Verification surface for the VERIFRAX public perimeter.">
   <style>
     @import url("./surface-system/shell/base.css");
     textarea{width:100%;min-height:220px;font-family:var(--vf-font-mono);background:var(--vf-panel-2);color:var(--vf-text);border:1px solid var(--vf-line);border-radius:var(--vf-radius-2);padding:var(--vf-space-4)}
@@ -19,7 +19,7 @@
     
 <p>Canonical verification surface.</p>
 <p>This surface verifies published proof. It does not publish proof, issue authority, execute governed actions, or accept intake.</p>
-    <p class="surface-role">Public verifier surface for proof structure inspection.</p>
+    <p class="surface-role">Verification surface for the VERIFRAX public perimeter.</p>
     <p class="surface-boundary">This surface inspects proof structure. It does not publish proof, issue authority, execute runtime actions, or operate archive retrieval.</p>
 
     <section class="panel">
@@ -52,6 +52,19 @@
         <a href="https://status.verifrax.net/">Status</a>
       </div>
     </section>
+  
+    <div class="pills">
+        <a href="https://www.verifrax.net/">Root</a>
+        <a href="https://proof.verifrax.net/">Proof</a>
+        <a href="https://docs.verifrax.net/">Docs</a>
+        <a href="https://apply.verifrax.net/">Apply</a>
+        <a href="https://api.verifrax.net/">Execution</a>
+        <a href="https://auctoriseal.verifrax.net/">Authority</a>
+        <a href="https://corpiform.verifrax.net/">Runtime</a>
+        <a href="https://cicullis.verifrax.net/">Enforcement</a>
+        <a href="https://sigillarium.verifrax.net/">Archive</a>
+        <a href="https://status.verifrax.net/">Status</a>
+    </div>
   </main>
 
   <script>

--- a/surface-preview/404.html
+++ b/surface-preview/404.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>VERIFRAX Verify</title>
-  <meta name="description" content="Public verifier surface for proof structure inspection.">
+  <meta name="description" content="Verification surface for the VERIFRAX public perimeter.">
   <link rel="stylesheet" href="assets/surface.css">
 </head>
 <body>
   <main class="wrap">
     <div class="kicker">VERIFRAX / verify</div>
     <h1>404 — VERIFRAX Verify</h1>
-    <p class="lead">Public verifier surface for proof structure inspection.</p>
+    <p class="lead">Verification surface for the VERIFRAX public perimeter.</p>
     <p class="copy">Bounded public tool surface inside the VERIFRAX perimeter.</p>
     <div class="rule"></div>
 

--- a/surface-preview/index.html
+++ b/surface-preview/index.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>VERIFRAX Verify</title>
-  <meta name="description" content="Public verifier surface for proof structure inspection.">
+  <meta name="description" content="Verification surface for the VERIFRAX public perimeter.">
   <link rel="stylesheet" href="assets/surface.css">
 </head>
 <body>
   <main class="wrap">
     <div class="kicker">VERIFRAX / verify</div>
     <h1>VERIFRAX Verify</h1>
-    <p class="lead">Public verifier surface for proof structure inspection.</p>
+    <p class="lead">Verification surface for the VERIFRAX public perimeter.</p>
     <p class="copy">Bounded public tool surface inside the VERIFRAX perimeter.</p>
     <div class="rule"></div>
 

--- a/surface.host.json
+++ b/surface.host.json
@@ -4,14 +4,18 @@
   "hostClass": "tool",
   "role": "verify",
   "title": "VERIFRAX Verify",
-  "description": "Public verifier surface for proof structure inspection. This surface verifies published proof. It does not publish proof, issue authority, execute governed actions, or accept intake.",
+  "description": "Verification surface for the VERIFRAX public perimeter. This surface verifies published proof only. It does not publish proof, issue authority, execute governed actions, or accept intake.",
   "deployMode": "static-root",
   "adjacentHosts": {
-    "Check": "https://verify.verifrax.net",
-    "Proof": "https://proof.verifrax.net",
+    "Root": "https://www.verifrax.net",
     "Docs": "https://docs.verifrax.net",
-    "Status": "https://status.verifrax.net",
+    "Proof": "https://proof.verifrax.net",
+    "Apply": "https://apply.verifrax.net",
+    "Execution": "https://api.verifrax.net",
     "Authority": "https://auctoriseal.verifrax.net",
-    "Runtime": "https://corpiform.verifrax.net"
+    "Runtime": "https://corpiform.verifrax.net",
+    "Enforcement": "https://cicullis.verifrax.net",
+    "Archive": "https://sigillarium.verifrax.net",
+    "Status": "https://status.verifrax.net"
   }
 }


### PR DESCRIPTION
## Summary
Realigns the verify host surface.

## Adds
- explicit verification-only boundary
- aligned adjacent surface references
- cleaned public host copy

## Boundary
This change updates the verify host surface only.

It does not publish proof, issue authority, execute governed actions, or accept intake.

## Why this change
The live verify host must be uniformly alive as a public system surface.
