### PR TITLE
Publish VERIFRAX verify root 404 artifact

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+verify.verifrax.net


### PR DESCRIPTION
## Summary
Publishes the VERIFRAX verify root surface and root 404 artifact.

## Adds
- Pages artifact now uses root index.html
- Pages artifact now includes root 404.html
- repository root CNAME for verify.verifrax.net

## Boundary
This change updates Pages publication only.

It does not change verification logic, proof publication, authority, execution, or intake boundaries.

## Why this change
The live verify host must publish the canonical committed root surface and 404 surface on the configured custom domain.
