### PR TITLE
Materialize canonical proof artifact chain across repository boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@ Deterministic public verdict surface.
 Public verification repository for `https://verify.verifrax.net/`, serving a static verification surface for Verifrax proof material without becoming an authority issuer, proof publisher, execution runtime, archive surface, or evidence-root repository.
 
 
+## Proof artifacts
+
+This repository is part of the VERIFRAX proof perimeter.
+
+- **ARTIFACT-0006**
+- **ARTIFACT-0005**
+- **ARTIFACT-0004**
+- **ARTIFACT-0003**
+- **ARTIFACT-0002**
+- **ARTIFACT-0001**
+
+**Canonical public proof surface:** https://proof.verifrax.net  
+**Canonical proof publication repository:** https://github.com/Verifrax/proof  
+**Canonical evidence root:** https://github.com/Verifrax/VERIFRAX
+
 ## Terminal planes
 
 - **[ANAGNORIUM](https://github.com/Verifrax/ANAGNORIUM)** — terminal recognition


### PR DESCRIPTION
This change materializes the canonical proof artifact chain across the repository boundary.

- binds the repository surface to artifact-0006 through artifact-0001
- points the repository to the canonical proof publication surface
- strengthens public proof legibility at the boundary