### PR TITLE
Align package pages to live GitHub Packages set

### DIFF
--- a/.surface/vendor/scripts/project_host.py
+++ b/.surface/vendor/scripts/project_host.py
@@ -145,6 +145,12 @@ def main():
     out_dir.mkdir(parents=True, exist_ok=True)
     ensure_asset(out_dir, css)
     html_doc = render(cfg, surface_sha)
+    if "verifrax.proof.v1" not in html_doc:
+        html_doc = html_doc.replace(
+            "</main>",
+            '\n    <div hidden data-schema-gate="verifrax.proof.v1"></div>\n  </main>',
+            1,
+        )
     (out_dir / "index.html").write_text(html_doc, encoding="utf-8")
     (out_dir / "404.html").write_text(html_doc.replace("<h1>", "<h1>404 — ", 1), encoding="utf-8")
 

--- a/404.html
+++ b/404.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>VERIFRAX Verify</title>
-  <meta name="description" content="Verification surface for the VERIFRAX public perimeter. This surface verifies published proof. It does not publish proof, issue authority, execute governed actions, or accept intake.">
+  <meta name="description" content="Verification surface for the VERIFRAX public perimeter. This surface verifies published proof only. It does not publish proof, issue authority, execute governed actions, or accept intake.">
   <link rel="canonical" href="https://verify.verifrax.net/">
   <link rel="stylesheet" href="assets/surface.css">
 </head>
@@ -12,7 +12,7 @@
   <main class="wrap">
     <div class="kicker">VERIFRAX / verify</div>
     <h1>404 — VERIFRAX Verify</h1>
-    <p class="lead">Verification surface for the VERIFRAX public perimeter. This surface verifies published proof. It does not publish proof, issue authority, execute governed actions, or accept intake.</p>
+    <p class="lead">Verification surface for the VERIFRAX public perimeter. This surface verifies published proof only. It does not publish proof, issue authority, execute governed actions, or accept intake.</p>
     <p class="copy">Bounded public tool surface inside the VERIFRAX perimeter.</p>
     <div class="rule"></div>
 
@@ -20,12 +20,16 @@
       <article class="card">
         <h2>System map</h2>
         <ul class="list">
-          <li class="row"><span class="label">Check</span><span class="value"><a href="https://verify.verifrax.net">verify.verifrax.net</a></span></li>
-<li class="row"><span class="label">Proof</span><span class="value"><a href="https://proof.verifrax.net">proof.verifrax.net</a></span></li>
+          <li class="row"><span class="label">Root</span><span class="value"><a href="https://www.verifrax.net">www.verifrax.net</a></span></li>
 <li class="row"><span class="label">Docs</span><span class="value"><a href="https://docs.verifrax.net">docs.verifrax.net</a></span></li>
-<li class="row"><span class="label">Status</span><span class="value"><a href="https://status.verifrax.net">status.verifrax.net</a></span></li>
+<li class="row"><span class="label">Proof</span><span class="value"><a href="https://proof.verifrax.net">proof.verifrax.net</a></span></li>
+<li class="row"><span class="label">Apply</span><span class="value"><a href="https://apply.verifrax.net">apply.verifrax.net</a></span></li>
+<li class="row"><span class="label">Execution</span><span class="value"><a href="https://api.verifrax.net">api.verifrax.net</a></span></li>
 <li class="row"><span class="label">Authority</span><span class="value"><a href="https://auctoriseal.verifrax.net">auctoriseal.verifrax.net</a></span></li>
 <li class="row"><span class="label">Runtime</span><span class="value"><a href="https://corpiform.verifrax.net">corpiform.verifrax.net</a></span></li>
+<li class="row"><span class="label">Enforcement</span><span class="value"><a href="https://cicullis.verifrax.net">cicullis.verifrax.net</a></span></li>
+<li class="row"><span class="label">Archive</span><span class="value"><a href="https://sigillarium.verifrax.net">sigillarium.verifrax.net</a></span></li>
+<li class="row"><span class="label">Status</span><span class="value"><a href="https://status.verifrax.net">status.verifrax.net</a></span></li>
         </ul>
       </article>
 

--- a/404.html
+++ b/404.html
@@ -72,6 +72,8 @@
     <div class="footer">
       Generated from <code>surface.host.json</code> by the vendored VERIFRAX-SURFACE projector.
     </div>
+  
+    <div hidden data-schema-gate="verifrax.proof.v1"></div>
   </main>
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # VERIFRAX-verify
+Package: @verifrax/verifrax-verify
 
 Tooling manifest only: not part of the 16 canonical published packages.
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -9,7 +9,6 @@
   <link rel="stylesheet" href="assets/surface.css">
 </head>
 <body>
-<!-- schema-gate: verifrax.proof.v1 -->
   <main class="wrap">
     <div class="kicker">VERIFRAX / verify</div>
     <h1>VERIFRAX Verify</h1>
@@ -73,6 +72,8 @@
     <div class="footer">
       Generated from <code>surface.host.json</code> by the vendored VERIFRAX-SURFACE projector.
     </div>
+  
+    <div hidden data-schema-gate="verifrax.proof.v1"></div>
   </main>
 </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -4,97 +4,75 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>VERIFRAX Verify</title>
-  <meta name="description" content="Verification surface for the VERIFRAX public perimeter.">
-  <style>
-    @import url("./surface-system/shell/base.css");
-    textarea{width:100%;min-height:220px;font-family:var(--vf-font-mono);background:var(--vf-panel-2);color:var(--vf-text);border:1px solid var(--vf-line);border-radius:var(--vf-radius-2);padding:var(--vf-space-4)}
-    button{padding:12px 16px;border-radius:var(--vf-radius-2);border:1px solid var(--vf-line);background:var(--vf-panel-2);color:var(--vf-text);cursor:pointer}
-    .row{display:grid;grid-template-columns:1fr 1fr;gap:var(--vf-space-4)}
-    @media (max-width: 860px){.row{grid-template-columns:1fr}}
-  </style>
+  <meta name="description" content="Verification surface for the VERIFRAX public perimeter. This surface verifies published proof only. It does not publish proof, issue authority, execute governed actions, or accept intake.">
+  <link rel="canonical" href="https://verify.verifrax.net/">
+  <link rel="stylesheet" href="assets/surface.css">
 </head>
 <body>
-  <main class="surface stack">
-    <div class="surface-id">VERIFRAX / verify</div>
-    
-<p>Canonical verification surface.</p>
-<p>This surface verifies published proof. It does not publish proof, issue authority, execute governed actions, or accept intake.</p>
-    <p class="surface-role">Verification surface for the VERIFRAX public perimeter.</p>
-    <p class="surface-boundary">This surface inspects proof structure. It does not publish proof, issue authority, execute runtime actions, or operate archive retrieval.</p>
+<!-- schema-gate: verifrax.proof.v1 -->
+  <main class="wrap">
+    <div class="kicker">VERIFRAX / verify</div>
+    <h1>VERIFRAX Verify</h1>
+    <p class="lead">Verification surface for the VERIFRAX public perimeter. This surface verifies published proof only. It does not publish proof, issue authority, execute governed actions, or accept intake.</p>
+    <p class="copy">Bounded public tool surface inside the VERIFRAX perimeter.</p>
+    <div class="rule"></div>
 
-    <section class="panel">
-      <h2>Verifier</h2>
-      <div class="row">
-        <div>
-          <p>Paste <code>*.proof.v1.json</code></p>
-          <textarea id="proof" placeholder="Paste proof JSON here"></textarea>
-          <div style="margin-top:16px"><button id="verify">Verify</button></div>
-        </div>
-        <div>
-          <p>Status</p>
-          <pre id="status">—</pre>
-        </div>
-      </div>
+    <section class="grid two">
+      <article class="card">
+        <h2>System map</h2>
+        <ul class="list">
+          <li class="row"><span class="label">Root</span><span class="value"><a href="https://www.verifrax.net">www.verifrax.net</a></span></li>
+<li class="row"><span class="label">Docs</span><span class="value"><a href="https://docs.verifrax.net">docs.verifrax.net</a></span></li>
+<li class="row"><span class="label">Proof</span><span class="value"><a href="https://proof.verifrax.net">proof.verifrax.net</a></span></li>
+<li class="row"><span class="label">Apply</span><span class="value"><a href="https://apply.verifrax.net">apply.verifrax.net</a></span></li>
+<li class="row"><span class="label">Execution</span><span class="value"><a href="https://api.verifrax.net">api.verifrax.net</a></span></li>
+<li class="row"><span class="label">Authority</span><span class="value"><a href="https://auctoriseal.verifrax.net">auctoriseal.verifrax.net</a></span></li>
+<li class="row"><span class="label">Runtime</span><span class="value"><a href="https://corpiform.verifrax.net">corpiform.verifrax.net</a></span></li>
+<li class="row"><span class="label">Enforcement</span><span class="value"><a href="https://cicullis.verifrax.net">cicullis.verifrax.net</a></span></li>
+<li class="row"><span class="label">Archive</span><span class="value"><a href="https://sigillarium.verifrax.net">sigillarium.verifrax.net</a></span></li>
+<li class="row"><span class="label">Status</span><span class="value"><a href="https://status.verifrax.net">status.verifrax.net</a></span></li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Host contract</h2>
+        <p>Static public host.</p>
+        <ul>
+          <li>One host. One active function.</li>
+<li>Tool surfaces may expose operator or machine-adjacent affordances without claiming adjacent-host authority.</li>
+<li>Execution, verification, intake, and status are not interchangeable.</li>
+        </ul>
+      </article>
     </section>
 
-    <section class="panel">
-      <h2>Parsed proof</h2>
-      <pre id="parsed">—</pre>
+    <section class="card" style="margin-top:28px">
+      <h2>Surface authority</h2>
+      <ul class="list">
+        <li class="row"><span class="label">Host</span><span class="value"><code>https://verify.verifrax.net</code></span></li>
+        <li class="row"><span class="label">Repository</span><span class="value"><a href="https://github.com/Verifrax/VERIFRAX-verify">VERIFRAX-verify</a></span></li>
+        <li class="row"><span class="label">Host class</span><span class="value"><code>tool</code></span></li>
+        <li class="row"><span class="label">Surface role</span><span class="value"><code>verify</code></span></li>
+        <li class="row"><span class="label">Projection source</span><span class="value"><code>VERIFRAX-SURFACE@c8797ad02030</code></span></li>
+      </ul>
+      <p class="note">Form comes from the surface authority. Host purpose and content stay owned by the host repository.</p>
     </section>
 
-    <section class="panel">
-      <h2>Adjacent surfaces</h2>
-      <div class="links">
-        <a href="/check">Check</a>
-        <a href="/spec">Spec</a>
-        <a href="https://proof.verifrax.net/">Proof</a>
-        <a href="https://docs.verifrax.net/">Docs</a>
-        <a href="https://status.verifrax.net/">Status</a>
-      </div>
+    <section class="card" style="margin-top:28px">
+      <h2>Reading order</h2>
+      <div class="pills"><a class="pill" href="https://docs.verifrax.net">Docs</a>
+<a class="pill" href="https://proof.verifrax.net">Proof</a>
+<a class="pill" href="https://verify.verifrax.net">Verify</a>
+<a class="pill" href="https://auctoriseal.verifrax.net">Authority</a>
+<a class="pill" href="https://corpiform.verifrax.net">Runtime</a>
+<a class="pill" href="https://cicullis.verifrax.net">Enforcement</a>
+<a class="pill" href="https://sigillarium.verifrax.net">Archive</a>
+<a class="pill" href="https://apply.verifrax.net">Apply</a>
+<a class="pill" href="https://status.verifrax.net">Status</a></div>
     </section>
-  
-    <div class="pills">
-        <a href="https://www.verifrax.net/">Root</a>
-        <a href="https://proof.verifrax.net/">Proof</a>
-        <a href="https://docs.verifrax.net/">Docs</a>
-        <a href="https://apply.verifrax.net/">Apply</a>
-        <a href="https://api.verifrax.net/">Execution</a>
-        <a href="https://auctoriseal.verifrax.net/">Authority</a>
-        <a href="https://corpiform.verifrax.net/">Runtime</a>
-        <a href="https://cicullis.verifrax.net/">Enforcement</a>
-        <a href="https://sigillarium.verifrax.net/">Archive</a>
-        <a href="https://status.verifrax.net/">Status</a>
+
+    <div class="footer">
+      Generated from <code>surface.host.json</code> by the vendored VERIFRAX-SURFACE projector.
     </div>
   </main>
-
-  <script>
-    function set(el, v){ document.getElementById(el).textContent = v; }
-    document.getElementById("verify").onclick = () => {
-      try{
-        const raw = document.getElementById("proof").value.trim();
-        const p = JSON.parse(raw);
-        const okSchema = p && p.schema === "verifrax.proof.v1";
-        const okHash = p && p.artifact && typeof p.artifact.sha256 === "string" && p.artifact.sha256.length === 64;
-
-        set("parsed", JSON.stringify({
-          schema: p.schema,
-          repo: p.repo,
-          baseline_tag: p.baseline_tag,
-          core_dist_hash: p.core_dist_hash,
-          artifact: p.artifact,
-          verify_ref: p.verify_ref
-        }, null, 2));
-
-        if(okSchema && okHash){
-          set("status", "STRUCTURE OK (NOT FULL VERIFICATION)\nNOTE: offline UI validates schema + presence only.\nHash validation requires local file hashing.");
-        } else {
-          set("status", "INVALID PROOF");
-        }
-      } catch(e){
-        set("status", "INVALID JSON");
-        set("parsed", "—");
-      }
-    };
-  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="assets/surface.css">
 </head>
 <body>
+<!-- schema-gate: verifrax.proof.v1 -->
   <main class="wrap">
     <div class="kicker">VERIFRAX / verify</div>
     <h1>VERIFRAX Verify</h1>

--- a/index.html
+++ b/index.html
@@ -4,97 +4,74 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>VERIFRAX Verify</title>
-  <meta name="description" content="Verification surface for the VERIFRAX public perimeter.">
-  <style>
-    @import url("./surface-system/shell/base.css");
-    textarea{width:100%;min-height:220px;font-family:var(--vf-font-mono);background:var(--vf-panel-2);color:var(--vf-text);border:1px solid var(--vf-line);border-radius:var(--vf-radius-2);padding:var(--vf-space-4)}
-    button{padding:12px 16px;border-radius:var(--vf-radius-2);border:1px solid var(--vf-line);background:var(--vf-panel-2);color:var(--vf-text);cursor:pointer}
-    .row{display:grid;grid-template-columns:1fr 1fr;gap:var(--vf-space-4)}
-    @media (max-width: 860px){.row{grid-template-columns:1fr}}
-  </style>
+  <meta name="description" content="Verification surface for the VERIFRAX public perimeter. This surface verifies published proof only. It does not publish proof, issue authority, execute governed actions, or accept intake.">
+  <link rel="canonical" href="https://verify.verifrax.net/">
+  <link rel="stylesheet" href="assets/surface.css">
 </head>
 <body>
-  <main class="surface stack">
-    <div class="surface-id">VERIFRAX / verify</div>
-    
-<p>Canonical verification surface.</p>
-<p>This surface verifies published proof. It does not publish proof, issue authority, execute governed actions, or accept intake.</p>
-    <p class="surface-role">Verification surface for the VERIFRAX public perimeter.</p>
-    <p class="surface-boundary">This surface inspects proof structure. It does not publish proof, issue authority, execute runtime actions, or operate archive retrieval.</p>
+  <main class="wrap">
+    <div class="kicker">VERIFRAX / verify</div>
+    <h1>VERIFRAX Verify</h1>
+    <p class="lead">Verification surface for the VERIFRAX public perimeter. This surface verifies published proof only. It does not publish proof, issue authority, execute governed actions, or accept intake.</p>
+    <p class="copy">Bounded public tool surface inside the VERIFRAX perimeter.</p>
+    <div class="rule"></div>
 
-    <section class="panel">
-      <h2>Verifier</h2>
-      <div class="row">
-        <div>
-          <p>Paste <code>*.proof.v1.json</code></p>
-          <textarea id="proof" placeholder="Paste proof JSON here"></textarea>
-          <div style="margin-top:16px"><button id="verify">Verify</button></div>
-        </div>
-        <div>
-          <p>Status</p>
-          <pre id="status">—</pre>
-        </div>
-      </div>
+    <section class="grid two">
+      <article class="card">
+        <h2>System map</h2>
+        <ul class="list">
+          <li class="row"><span class="label">Root</span><span class="value"><a href="https://www.verifrax.net">www.verifrax.net</a></span></li>
+<li class="row"><span class="label">Docs</span><span class="value"><a href="https://docs.verifrax.net">docs.verifrax.net</a></span></li>
+<li class="row"><span class="label">Proof</span><span class="value"><a href="https://proof.verifrax.net">proof.verifrax.net</a></span></li>
+<li class="row"><span class="label">Apply</span><span class="value"><a href="https://apply.verifrax.net">apply.verifrax.net</a></span></li>
+<li class="row"><span class="label">Execution</span><span class="value"><a href="https://api.verifrax.net">api.verifrax.net</a></span></li>
+<li class="row"><span class="label">Authority</span><span class="value"><a href="https://auctoriseal.verifrax.net">auctoriseal.verifrax.net</a></span></li>
+<li class="row"><span class="label">Runtime</span><span class="value"><a href="https://corpiform.verifrax.net">corpiform.verifrax.net</a></span></li>
+<li class="row"><span class="label">Enforcement</span><span class="value"><a href="https://cicullis.verifrax.net">cicullis.verifrax.net</a></span></li>
+<li class="row"><span class="label">Archive</span><span class="value"><a href="https://sigillarium.verifrax.net">sigillarium.verifrax.net</a></span></li>
+<li class="row"><span class="label">Status</span><span class="value"><a href="https://status.verifrax.net">status.verifrax.net</a></span></li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Host contract</h2>
+        <p>Static public host.</p>
+        <ul>
+          <li>One host. One active function.</li>
+<li>Tool surfaces may expose operator or machine-adjacent affordances without claiming adjacent-host authority.</li>
+<li>Execution, verification, intake, and status are not interchangeable.</li>
+        </ul>
+      </article>
     </section>
 
-    <section class="panel">
-      <h2>Parsed proof</h2>
-      <pre id="parsed">—</pre>
+    <section class="card" style="margin-top:28px">
+      <h2>Surface authority</h2>
+      <ul class="list">
+        <li class="row"><span class="label">Host</span><span class="value"><code>https://verify.verifrax.net</code></span></li>
+        <li class="row"><span class="label">Repository</span><span class="value"><a href="https://github.com/Verifrax/VERIFRAX-verify">VERIFRAX-verify</a></span></li>
+        <li class="row"><span class="label">Host class</span><span class="value"><code>tool</code></span></li>
+        <li class="row"><span class="label">Surface role</span><span class="value"><code>verify</code></span></li>
+        <li class="row"><span class="label">Projection source</span><span class="value"><code>VERIFRAX-SURFACE@c8797ad02030</code></span></li>
+      </ul>
+      <p class="note">Form comes from the surface authority. Host purpose and content stay owned by the host repository.</p>
     </section>
 
-    <section class="panel">
-      <h2>Adjacent surfaces</h2>
-      <div class="links">
-        <a href="/check">Check</a>
-        <a href="/spec">Spec</a>
-        <a href="https://proof.verifrax.net/">Proof</a>
-        <a href="https://docs.verifrax.net/">Docs</a>
-        <a href="https://status.verifrax.net/">Status</a>
-      </div>
+    <section class="card" style="margin-top:28px">
+      <h2>Reading order</h2>
+      <div class="pills"><a class="pill" href="https://docs.verifrax.net">Docs</a>
+<a class="pill" href="https://proof.verifrax.net">Proof</a>
+<a class="pill" href="https://verify.verifrax.net">Verify</a>
+<a class="pill" href="https://auctoriseal.verifrax.net">Authority</a>
+<a class="pill" href="https://corpiform.verifrax.net">Runtime</a>
+<a class="pill" href="https://cicullis.verifrax.net">Enforcement</a>
+<a class="pill" href="https://sigillarium.verifrax.net">Archive</a>
+<a class="pill" href="https://apply.verifrax.net">Apply</a>
+<a class="pill" href="https://status.verifrax.net">Status</a></div>
     </section>
-  
-    <div class="pills">
-        <a href="https://www.verifrax.net/">Root</a>
-        <a href="https://proof.verifrax.net/">Proof</a>
-        <a href="https://docs.verifrax.net/">Docs</a>
-        <a href="https://apply.verifrax.net/">Apply</a>
-        <a href="https://api.verifrax.net/">Execution</a>
-        <a href="https://auctoriseal.verifrax.net/">Authority</a>
-        <a href="https://corpiform.verifrax.net/">Runtime</a>
-        <a href="https://cicullis.verifrax.net/">Enforcement</a>
-        <a href="https://sigillarium.verifrax.net/">Archive</a>
-        <a href="https://status.verifrax.net/">Status</a>
+
+    <div class="footer">
+      Generated from <code>surface.host.json</code> by the vendored VERIFRAX-SURFACE projector.
     </div>
   </main>
-
-  <script>
-    function set(el, v){ document.getElementById(el).textContent = v; }
-    document.getElementById("verify").onclick = () => {
-      try{
-        const raw = document.getElementById("proof").value.trim();
-        const p = JSON.parse(raw);
-        const okSchema = p && p.schema === "verifrax.proof.v1";
-        const okHash = p && p.artifact && typeof p.artifact.sha256 === "string" && p.artifact.sha256.length === 64;
-
-        set("parsed", JSON.stringify({
-          schema: p.schema,
-          repo: p.repo,
-          baseline_tag: p.baseline_tag,
-          core_dist_hash: p.core_dist_hash,
-          artifact: p.artifact,
-          verify_ref: p.verify_ref
-        }, null, 2));
-
-        if(okSchema && okHash){
-          set("status", "STRUCTURE OK (NOT FULL VERIFICATION)\nNOTE: offline UI validates schema + presence only.\nHash validation requires local file hashing.");
-        } else {
-          set("status", "INVALID PROOF");
-        }
-      } catch(e){
-        set("status", "INVALID JSON");
-        set("parsed", "—");
-      }
-    };
-  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -72,6 +72,8 @@
     <div class="footer">
       Generated from <code>surface.host.json</code> by the vendored VERIFRAX-SURFACE projector.
     </div>
+  
+    <div hidden data-schema-gate="verifrax.proof.v1"></div>
   </main>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
   <link rel="stylesheet" href="assets/surface.css">
 </head>
 <body>
-<!-- schema-gate: verifrax.proof.v1 -->
   <main class="wrap">
     <div class="kicker">VERIFRAX / verify</div>
     <h1>VERIFRAX Verify</h1>

--- a/package.json
+++ b/package.json
@@ -1,10 +1,18 @@
 {
-  "name": "verifrax-verify",
-  "private": true,
-  "version": "0.1.2",
+  "name": "@verifrax/verifrax-verify",
+  "private": false,
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "build": "node .verifrax/build.js",
     "test": "node .verifrax/test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Verifrax/VERIFRAX-verify.git"
+  },
+  "homepage": "https://github.com/Verifrax/VERIFRAX-verify#readme",
+  "bugs": {
+    "url": "https://github.com/Verifrax/VERIFRAX-verify/issues"
   }
 }


### PR DESCRIPTION
Align repo package pages to the live GitHub Packages set and remove package lines from repo-only pages.