### PR TITLE
Set package.json license metadata to Apache-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,6 @@
   "homepage": "https://github.com/Verifrax/VERIFRAX-verify#readme",
   "bugs": {
     "url": "https://github.com/Verifrax/VERIFRAX-verify/issues"
-  }
+  },
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
Set package.json license metadata to Apache-2.0 only. No version change. No publish.