### PR TITLE
Publish @verifrax/verifrax-verify@0.1.5 with Apache-2.0 license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verifrax/verifrax-verify",
   "private": false,
-  "version": "0.1.3",
+  "version": "0.1.5",
   "type": "module",
   "scripts": {
     "build": "node .verifrax/build.js",


### PR DESCRIPTION
Set package.json license metadata to Apache-2.0 and publish @verifrax/verifrax-verify@0.1.5. No other package touched.