### PR TITLE
Restore @verifrax/verifrax-verify version to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verifrax/verifrax-verify",
   "private": false,
-  "version": "0.1.5",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "build": "node .verifrax/build.js",


### PR DESCRIPTION
Restore package.json version to 0.1.4 and keep Apache-2.0 license metadata. No publish.