### PR TITLE
Constrain npm package boundary to the verified minimum publish surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,14 @@
   "bugs": {
     "url": "https://github.com/Verifrax/VERIFRAX-verify/issues"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "files": [
+    ".verifrax/build.js",
+    ".verifrax/test.js",
+    "index.html",
+    "assets/surface.css",
+    "dist/index.html",
+    "README.md",
+    "LICENSE"
+  ]
 }


### PR DESCRIPTION
## Summary
Constrain the npm package boundary for @verifrax/verifrax-verify to the verified minimum publish surface.

## Scope
- add exact files allowlist in package.json
- no license change
- no package version bump
- no publish in this change

## Verification
- repack on the republish branch resolved to exactly 8 files
- package boundary now matches the verified minimum surface
- direct push to main is blocked by repository rules, so this change is routed through PR
