### PR TITLE
Align package version and verify gate to published 0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verifrax/verifrax-verify",
   "private": false,
-  "version": "0.1.4",
+  "version": "0.1.6",
   "type": "module",
   "scripts": {
     "build": "node .verifrax/build.js",


### PR DESCRIPTION
Package version in package.json lagged behind npm latest, and the verify workflow still asserted the old version.