### PR TITLE
Complete verification result object-family publication

### DIFF
--- a/verifications/current/index.json
+++ b/verifications/current/index.json
@@ -1,0 +1,13 @@
+{
+  "object_type": "verification-result-index",
+  "schema_version": "1.0.0",
+  "status": "ACTIVE_TRUTH",
+  "current": "verification-result-0001.json",
+  "entries": [
+    {
+      "object_id": "verification-result-0001",
+      "path": "verifications/current/verification-result-0001.json",
+      "status": "ACTIVE_TRUTH"
+    }
+  ]
+}

--- a/verifications/current/verification-result-0001.json
+++ b/verifications/current/verification-result-0001.json
@@ -1,0 +1,28 @@
+{
+  "object_type": "verification-result",
+  "object_id": "verification-result-0001",
+  "schema_version": "1.0.0",
+  "status": "ACTIVE_TRUTH",
+  "truth_type": "ACTIVE_TRUTH",
+  "claim_class_id": "verification-result",
+  "governing_law_ref": "SYNTAGMARIUM/claim-classes/verification-result.json",
+  "accepted_epoch_ref": "ORBISTIUM/epochs/current/accepted-epoch-0001.json",
+  "verification_chamber": "VERIFRAX-verify",
+  "subject": {
+    "kind": "public-object-family",
+    "ref": "VERIFRAX-verify/verifications/current/"
+  },
+  "result": {
+    "verdict": "OBJECT_FAMILY_PRESENT",
+    "meaning": "The public verification-result object family is present as a bounded current object surface.",
+    "scope": "object-family publication only",
+    "not_a_claim": [
+      "not proof publication",
+      "not authority issuance",
+      "not governed execution",
+      "not terminal recognition",
+      "not terminal recourse"
+    ]
+  },
+  "created_at": "2026-04-25T00:00:00Z"
+}

--- a/verifications/history/README.md
+++ b/verifications/history/README.md
@@ -1,0 +1,6 @@
+# Verification Result History
+
+This directory is reserved for historical verification-result objects.
+
+Historical objects preserved here must not impersonate current verification truth.
+Current verification-result objects are indexed from `verifications/current/`.


### PR DESCRIPTION
Completes the published object-family surface for VERIFRAX-verify.

Scope:

* Adds current object-family index material.
* Adds the first typed current object file.
* Adds historical retention surface documentation.
* Keeps the repository role bounded.
* Does not change host, package, authority, execution, or adjacent chamber semantics.

Verification:

* Expected files exist.
* JSON files parse.
* Repository diff is limited to the object-family surface.
